### PR TITLE
PHP example: District ID is no longer required for Log in with Clever buttons

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -7,7 +7,7 @@ This example was built using procedural PHP. The sample code itself relies on no
 
 When run in a server context, `process_incoming_requests` will listen for incoming HTTP requests on the specified host and port after evaluating pertinent configuration options.
 
-Requests to "/" or any paths besides "/oauth" will be served a simple HTML page. If you've configured a Clever district ID, a "Sign in with Clever" link will be displayed. When that link is followed and authentication is completed on clever.com, the user will be redirected to this script's OAuth 2.0 redirect flow.
+Requests to "/" or any paths besides "/oauth" will be served a simple HTML page with a "Log in with Clever" button. When that link is followed and authentication is completed on clever.com, the user will be redirected to this script's OAuth 2.0 redirect flow.
 
 Requests to "/oauth" will be treated as OAuth 2.0 client redirects and passed to our `process_client_redirect` function to perform a few brief steps:
 
@@ -22,9 +22,7 @@ The sample code relies on some environment variables to easily set state. Use mo
 
 Use `bin/start_sample_server.sh` to easily start serving on `http://localhost:2587`.
 
-`CLEVER_CLIENT_ID=abc CLEVER_CLIENT_SECRET=xyz CLEVER_DISTRICT_ID=hjkl CLEVER_REDIRECT_BASE=http://localhost:2587 ./bin/start_sample_server.sh`
-
-A `CLEVER_DISTRICT_ID` is not required to handle incoming OAuth 2.0 redirects, but must be provided to generate Sign in with Clever links.
+`CLEVER_CLIENT_ID=abc CLEVER_CLIENT_SECRET=xyz CLEVER_REDIRECT_BASE=http://localhost:2587 ./bin/start_sample_server.sh`
 
 Set `CLEVER_REDIRECT_BASE` to use an alternate host and port combination for your server.
 

--- a/php/Test/indexTest.php
+++ b/php/Test/indexTest.php
@@ -99,12 +99,10 @@ class CleverInstantLoginExample extends PHPUnit_Framework_TestCase {
     $our_options = prepare_options_for_clever();
     $wanted_redirect_url = preg_quote(urlencode($our_options['client_redirect_url']));
     $wanted_client_id = preg_quote($our_options['client_id']);
-    $wanted_district_id = preg_quote($our_options['district_id']);
     $wanted_authorize_url = $our_options['clever_oauth_authorize_url'];
     $url = generate_sign_in_with_clever_url($our_options);
     $this->assertStringStartsWith($wanted_authorize_url, $url);
     $this->assertRegExp("@redirect_uri=$wanted_redirect_url@", $url);
-    $this->assertRegExp(("@district_id=$wanted_district_id@"), $url);
     $this->assertRegExp(("@client_id=$wanted_client_id@"), $url);
   }
 
@@ -126,7 +124,6 @@ function prepare_options_for_clever() {
   $options = array(
     'client_id' => 'abc',
     'client_secret' => 'def',
-    'district_id' => '123',
     'client_redirect_url' => 'http://localhost:1234/oauth',
     'clever_redirect_base' => 'http://localhost:1234',
     'clever_oauth_tokens_url' => 'http://localhost:1234/oauth/tokens',

--- a/php/env.sh.example
+++ b/php/env.sh.example
@@ -2,6 +2,5 @@
 # Retrieve your client ID, secret, and a district ID from your Clever developer dashboard
 export CLEVER_CLIENT_ID=x
 export CLEVER_CLIENT_SECRET=x
-export CLEVER_DISTRICT_ID=x
 export CLEVER_REDIRECT_BASE=http://localhost:2587
 export CLEVER_API_BASE=https://api.clever.com

--- a/php/index.php
+++ b/php/index.php
@@ -24,7 +24,6 @@ function set_options(array $override_options = NULL) {
     'client_id' => getenv('CLEVER_CLIENT_ID'),
     'client_secret' => getenv('CLEVER_CLIENT_SECRET'),
     'clever_redirect_base' => getenv('CLEVER_REDIRECT_BASE'),
-    'district_id' => getenv('CLEVER_DISTRICT_ID'),
     'clever_oauth_base' => 'https://clever.com/oauth',
     'clever_api_base' => 'https://api.clever.com',
   );
@@ -70,15 +69,10 @@ function process_incoming_requests($incoming_request_uri, array $options) {
       echo("</pre>");
     }
   } else {
-    if(!empty($options['district_id'])) {
-      // Our home page route will create a Clever Instant Login button for users from the district our $options['district_id'] is set to.
-      $sign_in_link = generate_sign_in_with_clever_link($options);
-      echo("<h1>clever_oauth_examples: Login!</h1>");
-      echo('<p>' . $sign_in_link . '</p>');
-    } else {
-      echo("<h1>clever_oauth_examples</h1>");
-      echo('<p>Configure a Clever District ID to create a Sign in with Clever button on this page.</p>');
-    }
+    // Our home page route will create a Clever Instant Login button for users
+    $sign_in_link = generate_sign_in_with_clever_link($options);
+    echo("<h1>clever_oauth_examples: Login!</h1>");
+    echo('<p>' . $sign_in_link . '</p>');
     echo("<p>Ready to handle OAuth 2.0 client redirects on {$options['client_redirect_url']}.</p>");
   }
 }
@@ -197,8 +191,7 @@ function generate_sign_in_with_clever_url(array $options) {
     'response_type' => 'code',
     'redirect_uri' => $options['client_redirect_url'],
     'client_id' => $options['client_id'],
-    'scope' => 'read:user_id read:sis',
-    'district_id' => $options['district_id']
+    'scope' => 'read:user_id read:teachers read:students'
   );
   $querystring = http_build_query($request_params);
   $url = $options['clever_oauth_authorize_url'] . '?' . $querystring;


### PR DESCRIPTION
Refactored to no longer require an explicitly declared district ID